### PR TITLE
Refreshed white-blue theme

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -22,7 +22,7 @@
   background: var(--card-gradient);
   border-radius: var(--radius-lg);
   padding: 1.25rem;
-  color: white;
+  color: var(--primary-dark);
   box-shadow: var(--shadow-lg);
   position: relative;
   overflow: hidden;
@@ -81,7 +81,7 @@
   height: 32px;
   border-radius: var(--radius-full);
   background: rgba(255, 255, 255, 0.2);
-  color: white;
+  color: var(--primary-dark);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -181,7 +181,7 @@
   font-weight: 600;
   font-size: 0.8rem;
   background: rgba(255,255,255,0.15);
-  color: white;
+  color: var(--primary-dark);
   cursor: pointer;
   transition: all 0.3s var(--animation-bounce);
   backdrop-filter: blur(5px);
@@ -235,7 +235,7 @@
   box-shadow: var(--shadow-lg);
   position: relative;
   overflow: hidden;
-  color: white;
+  color: var(--primary-dark);
 }
 
 .virtual-card::after {
@@ -352,7 +352,7 @@
     0 2px 8px rgba(0, 0, 0, 0.15),
     inset 0 1px 0 rgba(255, 255, 255, 0.1),
     0 0 0 1px rgba(255, 255, 255, 0.05);
-  color: white;
+  color: var(--primary-dark);
   padding: 1.5rem;
 }
 
@@ -717,12 +717,12 @@
 
 .card-front {
   background: var(--card-gradient);
-  color: white;
+  color: var(--primary-dark);
 }
 
 .card-back {
   background: var(--card-gradient);
-  color: white;
+  color: var(--primary-dark);
   transform: rotateY(180deg);
 }
 
@@ -794,7 +794,7 @@
   height: 40px;
   border-radius: var(--radius-full);
   background: var(--primary);
-  color: white;
+  color: var(--primary-dark);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -829,7 +829,7 @@
 
 .saved-card-pay-btn {
   background: var(--primary);
-  color: white;
+  color: var(--primary-dark);
   border: none;
   border-radius: var(--radius-md);
   padding: 0.8rem 1rem;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   
   <!-- CSS Modules -->
   <link rel="stylesheet" href="variables.css">
+  <link rel="stylesheet" href="visa-theme.css">
   <link rel="stylesheet" href="reset.css">
   <link rel="stylesheet" href="layout.css">
   <link rel="stylesheet" href="cards.css">

--- a/visa-card.css
+++ b/visa-card.css
@@ -49,8 +49,8 @@
 
 /* Estilos base de la tarjeta */
 .visa-card {
-  color: var(--card-text-white);
-  background-color: rgb(42, 41, 45);
+  color: var(--primary-dark);
+  background-color: var(--bg-card);
   border-radius: var(--card-border-radius);
   height: var(--card-height);
   width: var(--card-width);

--- a/visa-theme.css
+++ b/visa-theme.css
@@ -1,0 +1,23 @@
+:root {
+  --primary: #1a1f71;
+  --primary-light: #2a43b0;
+  --primary-dark: #101853;
+
+  /* Base backgrounds */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f7f7f7;
+  --bg-elevated: #ffffff;
+  --bg-card: #ffffff;
+
+  /* Text colors */
+  --text-primary: var(--primary-dark);
+  --text-secondary: var(--primary);
+  --text-link: var(--primary);
+
+  /* Neutral overrides */
+  --neutral-800: #1a2f7a;
+  --neutral-900: #101853;
+
+  /* Card styling */
+  --card-gradient: linear-gradient(135deg, #fefefe 0%, #e7ecff 100%);
+}


### PR DESCRIPTION
## Summary
- add `visa-theme.css` with Visa-inspired palette
- apply new theme in `index.html`
- set Visa card background to card color and text to blue
- use blue text for cards

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68527f5e7fa48324ab3cb081e8e3bfd2